### PR TITLE
adding lowerCaseHeaders or keys as configurable option

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -18,7 +18,7 @@ function CV(config, callback) {
   var wb = this.load_xlsx(config.input)
   var ws = this.ws(config, wb);
   var csv = this.csv(ws)
-  this.cvjson(csv, config.output, callback)
+  this.cvjson(csv, config.output, config.lowerCaseHeaders, callback)
 }
 
 CV.prototype.load_xlsx = function(input) {
@@ -39,7 +39,7 @@ CV.prototype.csv = function(ws) {
   return csv_file = xlsx.utils.make_csv(ws)
 }
 
-CV.prototype.cvjson = function(csv, output, callback) {
+CV.prototype.cvjson = function(csv, output, lowerCaseHeaders, callback) {
   var record = []
   var header = []
 
@@ -56,7 +56,8 @@ CV.prototype.cvjson = function(csv, output, callback) {
       }else{
         var obj = {};
         header.forEach(function(column, index) {
-          obj[column.trim()] = row[index].trim();
+          var key = lowerCaseHeaders ? column.trim().toLowerCase() : column.trim();
+          obj[key] = row[index].trim();
         })
         record.push(obj);
       }

--- a/sample/sample.js
+++ b/sample/sample.js
@@ -2,7 +2,8 @@ var xlsx_json = require('../')
 
 xlsx_json({
   input: __dirname + '/interview.xlsx',
-  output: __dirname + '/test.json'
+  output: __dirname + '/test.json',
+  lowerCaseHeaders:true
 }, function(err, result) {
   if(err) {
     console.error(err);


### PR DESCRIPTION
Hi there, Thanks for this useful module. I had a requirement to standardize headers to lowercase. This is to eliminate errors that can occur to careless casing. I could have done it after the module converts it to json but my records in excel could exceed upto 10,000 rows and hence it would be inefficient to again loop through and make the change. 
<b>Hence I have added `lowerCaseHeaders` as configurable option. If `undefined` or `false` the process would take place as usual and if `lowerCaseHeaders` is `true` it will change the headers/ keys to lower case in my json output.</b>

I have added the same in xls-to-json

<b>Please merge and update the npm package</b>

Thank You!