### PR TITLE
Update index.js Stopped moving last column to the first

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -46,7 +46,6 @@ CV.prototype.cvjson = function(csv, output, callback) {
   cvcsv()
     .from.string(csv)
     .transform( function(row){
-      row.unshift(row.pop());
       return row;
     })
     .on('record', function(row, index){


### PR DESCRIPTION
I see no reason why we are moving fields around. This stops that.  I have tested this and it works. The last column in my spreadsheet is now staying as the last field in the json file.