### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/DataGarage/node-xml-json",
   "dependencies": {
-    "xlsx": "0.7.6-g",
+    "xlsx": "0.7.12",
     "csv": "~0.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
"xlsx": "0.7.6-g" changed to "xlsx": "0.7.12" because the other specified version breaks the npm install