### PR TITLE
Resolved npm package reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/DataGarage/node-xml-json",
   "dependencies": {
-    "xlsx": "0.7.6-g",
+    "xlsx": "~0.7.6-g",
     "csv": "~0.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
xlsx (npm package) was not resolving to version 0.7.6-g correctly.
Updated version reference to '~0.7.6-g', which resolves to 0.7.12
successfully. Test suite cleared.